### PR TITLE
Improve Päättäri menu extraction

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,14 +27,14 @@
 <div>
 <p><b>Torstai 23.4.</b></p>
 <ul>
-<li>Chicken Parmegiano</li>
-<li>&amp; Sitruuna kastiketta (L, G)</li>
-<li>Päättärin ”Bacalao”</li>
-<li>&amp; yrttiöljyä (L, G)</li>
-<li>Peruna-sienipihvit</li>
-<li>&amp; yrtti creme fraiche (L, G)</li>
-<li>Aurinkokuivattutomaatti- pestopasta</li>
-<li>/belugalinssejä / kevätkasvikset</li>
+<li>Chicken Parmegiano
+&amp; Sitruuna kastiketta (L, G)</li>
+<li>Päättärin ”Bacalao”
+&amp; yrttiöljyä (L, G)</li>
+<li>Peruna-sienipihvit
+&amp; yrtti creme fraiche (L, G)</li>
+<li>Aurinkokuivattutomaatti- pestopasta
+/belugalinssejä / kevätkasvikset</li>
 <li>Pehmis &amp; lisukkeet (L, G)</li>
 </ul>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 certifi==2024.7.4
 charset-normalizer==3.3.2
 idna==3.8
-lxml>=6.0.0
-requests==2.32.5
-urllib3==2.6.0
+cssselect==1.4.0

--- a/scraper.py
+++ b/scraper.py
@@ -52,11 +52,10 @@ def get_paattari_menu(day_of_week=0):
     url = 'https://nordrest.fi/ravintola-paattari/'
     page = requests.get(url)
     tree = html.fromstring(page.content)
-    lines = [
-        text.strip() for text in tree.xpath('//text()')
-        if text and text.strip()
-    ]
-    menu_block = lines
+    lunch_heading = tree.xpath("//*[starts-with(text(), 'LOUNASLISTA')]")[0]
+    menu_div = lunch_heading.xpath("ancestor::div[1]")[0]
+    menu_block = [x.text_content() for x in menu_div]
+
     day_names = ['MAANANTAI', 'TIISTAI', 'KESKIVIIKKO', 'TORSTAI', 'PERJANTAI']
     current_day = day_names[min(max(day_of_week, 0), 4)]
     end_tokens = {'HINNAT', 'AUKIOLOAJAT'}


### PR DESCRIPTION
The change first homes in on the roughly appropriate element with XPath magic, and then uses text_content() to get the menu item text in one string.